### PR TITLE
CI: some improvements in printing and folder structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
 
       - name: Run tool on all benchmarks
         working-directory: times-excel-reader
-        run: python utils/run_benchmarks.py ../benchmarks
+        run: python utils/run_benchmarks.py ../benchmarks --verbose

--- a/utils/run_benchmarks.py
+++ b/utils/run_benchmarks.py
@@ -13,12 +13,15 @@ from typing import Tuple
 
 
 def run_benchmark(
-    benchmarks_folder: str, benchmark_name: str, skip_csv: bool = False
+    benchmarks_folder: str,
+    benchmark_name: str,
+    skip_csv: bool = False,
+    out_folder: str = "out",
 ) -> Tuple[float, float, int, int]:
     xl_folder = path.join(benchmarks_folder, "xlsx", benchmark_name)
     dd_folder = path.join(benchmarks_folder, "dd", benchmark_name)
     csv_folder = path.join(benchmarks_folder, "csv", benchmark_name)
-    out_folder = path.join(benchmarks_folder, "out", benchmark_name)
+    out_folder = path.join(benchmarks_folder, out_folder, benchmark_name)
 
     # First convert ground truth DD to csv
     if not skip_csv:
@@ -60,7 +63,7 @@ def run_benchmark(
         text=True,
     )
     runtime = time.time() - start
-    with open(path.join(benchmarks_folder, "out", f"{benchmark_name}.out"), "w") as f:
+    with open(path.join(out_folder, "stdout"), "w") as f:
         f.write(res.stdout)
 
     if res.returncode == 0:
@@ -120,7 +123,9 @@ def run_all_benchmarks(benchmarks_folder, skip_csv=False):
     print("Running benchmarks on main", end="", flush=True)
     results_main = []
     for benchmark_name in benchmarks:
-        result = run_benchmark(benchmarks_folder, benchmark_name, skip_csv=True)
+        result = run_benchmark(
+            benchmarks_folder, benchmark_name, skip_csv=True, out_folder="out-main"
+        )
         results_main.append((benchmark_name, *result))
         print(".", end="", flush=True)
     print("\n\n" + tabulate(results_main, headers, floatfmt=".1f") + "\n")

--- a/utils/run_benchmarks.py
+++ b/utils/run_benchmarks.py
@@ -153,13 +153,21 @@ def run_all_benchmarks(benchmarks_folder, skip_csv=False, verbose=False):
         how="outer",
     )
     if df.isna().values.any():
-        print("ERROR: number of benchmarks changed")
+        print(f"ERROR: number of benchmarks changed:\n{df}")
         sys.exit(1)
     accu_regressions = df[df["Correct Rows"] < df["M Correct Rows"]]["Benchmark"]
     addi_regressions = df[df["Additional Rows"] > df["M Additional Rows"]]["Benchmark"]
     time_regressions = df[df["Time (s)"] > 2 * df["M Time (s)"]]["Benchmark"]
 
+    runtime_change = df["Time (s)"].sum() - df["M Time (s)"].sum()
+    print(f"Change in runtime: {runtime_change}")
+    correct_change = df["Correct Rows"].sum() - df["M Correct Rows"].sum()
+    print(f"Change in correct rows: {correct_change}")
+    additional_change = df["Additional Rows"].sum() - df["M Additional Rows"].sum()
+    print(f"Change in additional rows: {additional_change}")
+
     if len(accu_regressions) + len(addi_regressions) + len(time_regressions) > 0:
+        print()
         if not accu_regressions.empty:
             print(f"ERROR: correct rows regressed on: {', '.join(accu_regressions)}")
         if not addi_regressions.empty:

--- a/utils/run_benchmarks.py
+++ b/utils/run_benchmarks.py
@@ -145,10 +145,10 @@ def run_all_benchmarks(benchmarks_folder, skip_csv=False, verbose=False):
     combined_results = [
         (
             b,
-            f"{t:5.1f} {t0:5.1f}",
-            f"{a:5.1f} {a0:5.1f}",
-            f"{c:6d} {c0:6d}",
-            f"{d:6d} {d0:6d}",
+            f"{t0:5.1f} {t:5.1f}",
+            f"{a0:5.1f} {a:5.1f}",
+            f"{c0:6d} {c:6d}",
+            f"{d0:6d} {d:6d}",
         )
         for ((b, t, a, c, d), (_, t0, a0, c0, d0)) in zip(results, results_main)
     ]


### PR DESCRIPTION
- Add a `--verbose` flag to `run_benchmarks.py` and use it in the CI. This allows us to see the output of each run. (Note that we'll see the output for each run on your branch, as well as each run on `main`.)
- Modified the table printed at the end to have 2 numbers in each column: first is the result on the main branch, second on your branch. This should make comparisons easier.
- Also print a summary of changes at the end.
- `run_benchmarks.py` uses a folder `benchmarks/out-main/` to store the output of the runs on `main`, instead of re-using the `benchmarks/out/` folder. This should allow you to diff between the outputs etc.
