### PR TITLE
Filter out None values before producing output tables

### DIFF
--- a/times_reader/main.py
+++ b/times_reader/main.py
@@ -304,7 +304,10 @@ def produce_times_tables(
                 df.drop(columns=cols_to_drop, inplace=True)
                 df.drop_duplicates(inplace=True)
                 df.reset_index(drop=True, inplace=True)
-                i = df[mapping.times_cols[-1]].notna()
+                # TODO this is a hack. Use pd.StringDtype() so that notna() is sufficient
+                i = df[mapping.times_cols[-1]].notna() & (
+                    df[mapping.times_cols[-1]] != "None"
+                )
                 df = df.loc[i, mapping.times_cols]
                 result[mapping.times_name] = df
 


### PR DESCRIPTION
This is a temporary fix for https://github.com/samwebster/times-excel-reader/issues/47

We should really be using the proper dtypes for string columns so that the `pd.dropna` function is sufficient.