### PR TITLE
CI: (re)print summary in a separate step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,8 @@ jobs:
 
       - name: Run tool on all benchmarks
         working-directory: times-excel-reader
-        run: python utils/run_benchmarks.py ../benchmarks --verbose
+        run: python utils/run_benchmarks.py ../benchmarks --verbose | tee all.out
+
+      - name: Print summary
+        working-directory: times-excel-reader
+        run: sed -n '/Benchmark *Time.*Accuracy/h;//!H;$!d;x;//p' all.out


### PR DESCRIPTION
Just to make it easier to quickly see the results of the regression test. The full stdout of all runs is still available in the previous step.