### PR TITLE
Allow specifying a list of input XL files to process

### DIFF
--- a/times_excel_reader.py
+++ b/times_excel_reader.py
@@ -1,11 +1,15 @@
 from pathlib import Path
 import argparse
+import os.path
+import sys
 import times_reader
 
 if __name__ == "__main__":
     args_parser = argparse.ArgumentParser()
     args_parser.add_argument(
-        "input_dir", type=str, help="Input directory containing xlsx files"
+        "input",
+        nargs="*",
+        help="Either an input directory, or a list of input xlsx files to process",
     )
     args_parser.add_argument(
         "--output_dir", type=str, default="output", help="Output directory"
@@ -20,12 +24,19 @@ if __name__ == "__main__":
 
     mappings = times_reader.read_mappings("times_mapping.txt")
 
-    input_files = [
-        str(path)
-        for path in Path(args.input_dir).rglob("*.xlsx")
-        if not path.name.startswith("~")
-    ]
-    print(f"Loading {len(input_files)} files from {args.input_dir}")
+    if not isinstance(args.input, list) or len(args.input) < 1:
+        print(f"ERROR: expected at least 1 input. Got {args.input}")
+        sys.exit(1)
+    elif len(args.input) == 1:
+        assert os.path.isdir(args.input[0])
+        input_files = [
+            str(path)
+            for path in Path(args.input[0]).rglob("*.xlsx")
+            if not path.name.startswith("~")
+        ]
+        print(f"Loading {len(input_files)} files from {args.input[0]}")
+    else:
+        input_files = args.input
 
     tables = times_reader.convert_xl_to_times(
         input_files, args.output_dir, mappings, args.use_pkl


### PR DESCRIPTION
This is part 1 of 2 of the feature of specifying which input XLSX files to process for each "run" (the first step towards solving #41). This PR modifies the tool to accept either a single directory or a list of XLSX files as input.

Part 2 (#72) will introduce a YAML file that specifies this for each of our benchmarks.