### PR TITLE
Use a YAML file to specify the input XL files for each benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -36,12 +36,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: olejandro/demos-dd
-          path: benchmarks/dd
+          path: times-excel-reader/benchmarks/dd
 
       - uses: actions/checkout@v3
         with:
           repository: olejandro/demos-xlsx
-          path: benchmarks/xlsx
+          path: times-excel-reader/benchmarks/xlsx
           token: ${{ secrets.GH_PAT_DEMOS_XLSX }}
 
       # ---------- Prepare TIMES Ireland Model
@@ -51,12 +51,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: samwebster/times-ireland-model
-          path: benchmarks/xlsx/Ireland
+          path: times-excel-reader/benchmarks/xlsx/Ireland
 
       - uses: actions/checkout@v3
         with:
           repository: olejandro/times-ireland-model_gams
-          path: benchmarks/dd/Ireland
+          path: times-excel-reader/benchmarks/dd/Ireland
 
       # ---------- Run tool, check for regressions
 
@@ -67,7 +67,7 @@ jobs:
         # Save the return code to retcode.txt so that the next step can fail the action
         # if run_benchmarks.py failed.
         run: |
-          (python utils/run_benchmarks.py ../benchmarks --verbose | tee out.txt; \
+          (python utils/run_benchmarks.py benchmarks.yml --verbose | tee out.txt; \
             echo ${PIPESTATUS[0]} > retcode.txt)
 
       - name: Print summary

--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -1,0 +1,74 @@
+# This file specifies all the benchmarks we run on our CI
+#
+# Assumes `benchmarks_folder` contains subdirectories `xlsx` and `dd`.
+# `input_folder` and `dd_folder` are paths relative to `benchmarks_folder/xlsx` and
+# `benchmarks_folder/dd` respectively.
+# If `inputs` is not specified, all xlsx files in `input_folder` will be used.
+
+benchmarks_folder: benchmarks/
+benchmarks:
+  - name: DemoS_001-all
+    input_folder: DemoS_001
+    dd_folder: DemoS_001-all
+  - name: DemoS_002-all
+    input_folder: DemoS_002
+    dd_folder: DemoS_002-all
+  - name: DemoS_003-all
+    input_folder: DemoS_003
+    dd_folder: DemoS_003-all
+  - name: DemoS_004
+    input_folder: DemoS_004
+    inputs:
+      - "BY_Trans.xlsx"
+      - "Sets-DemoModels.xlsx"
+      - "SysSettings.xlsx"
+      - "VT_REG_PRI_V04.xlsx"
+    dd_folder: DemoS_004
+  - name: DemoS_004a
+    input_folder: DemoS_004
+    inputs:
+      - "BY_Trans.xlsx"
+      - "Sets-DemoModels.xlsx"
+      - "SysSettings.xlsx"
+      - "SuppXLS/Scen_Peak_RSV.xlsx"
+      - "VT_REG_PRI_V04.xlsx"
+    dd_folder: DemoS_004a
+  - name: DemoS_004b
+    input_folder: DemoS_004
+    inputs:
+      - "BY_Trans.xlsx"
+      - "Sets-DemoModels.xlsx"
+      - "SysSettings.xlsx"
+      - "SuppXLS/Scen_Peak_RSV-FLX.xlsx"
+      - "VT_REG_PRI_V04.xlsx"
+    dd_folder: DemoS_004b
+  - name: DemoS_004-all
+    input_folder: DemoS_004
+    dd_folder: DemoS_004-all
+  - name: DemoS_005-all
+    input_folder: DemoS_005
+    dd_folder: DemoS_005-all
+  - name: DemoS_006-all
+    input_folder: DemoS_006
+    dd_folder: DemoS_006-all
+  - name: DemoS_007-all
+    input_folder: DemoS_007
+    dd_folder: DemoS_007-all
+  - name: DemoS_008-all
+    input_folder: DemoS_008
+    dd_folder: DemoS_008-all
+  - name: DemoS_009-all
+    input_folder: DemoS_009
+    dd_folder: DemoS_009-all
+  - name: DemoS_010-all
+    input_folder: DemoS_010
+    dd_folder: DemoS_010-all
+  - name: DemoS_011-all
+    input_folder: DemoS_011
+    dd_folder: DemoS_011-all
+  - name: DemoS_012-all
+    input_folder: DemoS_012
+    dd_folder: DemoS_012-all
+  - name: Ireland
+    input_folder: Ireland
+    dd_folder: Ireland

--- a/times_excel_reader.py
+++ b/times_excel_reader.py
@@ -1,11 +1,15 @@
 from pathlib import Path
 import argparse
+import os.path
+import sys
 import times_reader
 
 if __name__ == "__main__":
     args_parser = argparse.ArgumentParser()
     args_parser.add_argument(
-        "input_dir", type=str, help="Input directory containing xlsx files"
+        "input",
+        nargs="*",
+        help="Either an input directory, or a list of input xlsx files to process",
     )
     args_parser.add_argument(
         "--output_dir", type=str, default="output", help="Output directory"
@@ -20,12 +24,19 @@ if __name__ == "__main__":
 
     mappings = times_reader.read_mappings("times_mapping.txt")
 
-    input_files = [
-        str(path)
-        for path in Path(args.input_dir).rglob("*.xlsx")
-        if not path.name.startswith("~")
-    ]
-    print(f"Loading {len(input_files)} files from {args.input_dir}")
+    if not isinstance(args.input, list) or len(args.input) < 1:
+        print(f"ERROR: expected at least 1 input. Got {args.input}")
+        sys.exit(1)
+    elif len(args.input) == 1:
+        assert os.path.isdir(args.input[0])
+        input_files = [
+            str(path)
+            for path in Path(args.input[0]).rglob("*.xlsx")
+            if not path.name.startswith("~")
+        ]
+        print(f"Loading {len(input_files)} files from {args.input[0]}")
+    else:
+        input_files = args.input
 
     tables = times_reader.convert_xl_to_times(
         input_files, args.output_dir, mappings, args.use_pkl


### PR DESCRIPTION
This is part 2 of 2 of the feature of specifying which input XLSX files to process for each "run" (the first step towards solving https://github.com/samwebster/times-excel-reader/issues/41).

This part introduces a YAML file that specifies the input files to be processed for each of our benchmarks. This needs #71 to be merged into main before CI will pass.